### PR TITLE
Google OAuth2 Support

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -10,6 +10,7 @@ lib/WWW/Contact/BG/Mail.pm
 lib/WWW/Contact/CN/163.pm
 lib/WWW/Contact/Gmail.pm
 lib/WWW/Contact/GoogleContactsAPI.pm
+lib/WWW/Contact/GoogleContactsAPIOAuth2.pm
 lib/WWW/Contact/Hotmail.pm
 lib/WWW/Contact/Indiatimes.pm
 lib/WWW/Contact/Lycos.pm

--- a/META.yml
+++ b/META.yml
@@ -37,6 +37,9 @@ provides:
   WWW::Contact::GoogleContactsAPI:
     file: lib/WWW/Contact/GoogleContactsAPI.pm
     version: 0.44
+  WWW::Contact::GoogleContactsAPIOAuth2:
+    file: lib/WWW/Contact/GoogleContactsAPIOAuth2.pm
+    version: 0.001
   WWW::Contact::Hotmail:
     file: lib/WWW/Contact/Hotmail.pm
     version: 0.46

--- a/lib/WWW/Contact.pm
+++ b/lib/WWW/Contact.pm
@@ -3,7 +3,7 @@ package WWW::Contact;
 use Class::MOP ();
 use Moose;
 
-our $VERSION   = '0.48';
+our $VERSION   = '0.49';
 our $AUTHORITY = 'cpan:FAYLAND';
 
 has 'errstr'   => ( is => 'rw', isa => 'Maybe[Str]' );

--- a/lib/WWW/Contact/GoogleContactsAPI.pm
+++ b/lib/WWW/Contact/GoogleContactsAPI.pm
@@ -43,7 +43,7 @@ sub get_contacts {
         $self->errstr("Wrong Username or Password");
         return;
     }
-	my $url = "http://www.google.com/m8/feeds/contacts/default/full"
+	my $url = "https://www.google.com/m8/feeds/contacts/default/full"
 		. "?max-results=9999&alt=json";
 	$url .= "&v=3.0";					# Gives more fields
     $self->get($url, $self->authsub->auth_params)

--- a/lib/WWW/Contact/GoogleContactsAPIOAuth2.pm
+++ b/lib/WWW/Contact/GoogleContactsAPIOAuth2.pm
@@ -1,0 +1,71 @@
+package WWW::Contact::GoogleContactsAPIOAuth2::MockResponse;
+use Moose;
+
+sub is_success { 1 }
+
+package WWW::Contact::GoogleAuthSubWrapper;
+use Moose;
+ 
+our $VERSION   = '0.001';
+
+has access_token => ( is => 'rw' );
+
+sub login {
+    my ( $self, $email, $access_token ) =  @_;
+    $self->access_token( $access_token );
+
+    # Just return a Mock Response that always has is_succes
+    # to fake out GoogleContactsAPI
+    return WWW::Contact::GoogleContactsAPIOAuth2::MockResponse->new;
+}
+
+sub auth_params { ( Authorization => "OAuth " . $_[0]->access_token ); }
+
+package WWW::Contact::GoogleContactsAPIOAuth2;
+use Moose;
+extends 'WWW::Contact::GoogleContactsAPI';
+ 
+our $VERSION   = '0.001';
+
+has authsub => (
+    is => 'ro',
+    isa => 'WWW::Contact::GoogleAuthSubWrapper',
+    lazy => 1,
+    default => sub {
+        WWW::Contact::GoogleAuthSubWrapper->new;
+    },
+);
+
+1;
+
+=head1 SYNOPSIS
+
+    # Create a WWW::Contact object as usual
+    my $wc = WWW::Contact->new;
+
+    # Then we need to update the 'gmail.com' known_supplier
+    # to use this GoogleContactsAPIOAuth2 module instead of the
+    # default GoogleContactsAPI module.
+    my $ks = $wc->known_supplier;
+    $ks->{'gmail.com'} = 'GoogleContactsAPIOAuth2';
+    $wc->known_supplier( $ks );
+
+    # Pass in the access_token as the password
+    # And you get the contacts using OAuth rather than AuthSub with user/pass
+    my $contacts = $wc->get_contacts( $email, $access_token );
+
+=head1 DESCRIPTION
+    
+    This module allows you to get google contacts using an OAuth2 token
+    (Can be gotten with L<Net::Oauth2::Client>), rather than using AuthSub
+    with a username/passwerd.  Google has begun warning users when third
+    parties access their account with username/password, so it is becoming bad
+    practice to do so.  Using OAuth avoids this problem.
+
+    To use this module, you need to use something like L<Net::Oauth2::Client>
+    to retrieve a valid access token for the desired user.  Then you need to
+    replace the default C<known_supplier> for C<gmail.com> with
+    L<GoogleContactsAPIOAuth2> as shown above in the synopsis.  Then you simply
+    pass that C<OAuth> access token as the C<password> field when you call
+    get_contacts, and you get all of the contacts using OAuth.
+


### PR DESCRIPTION
I'm not sure if this is really the best way, but it seemed the quickest way with the least code duplication (using GoogleContactsAPI as the base).

It basically overrides the `AuthSub` with something that can accept a google OAuth `access_token` as the password, and use that appropriately.  It also returns `auth_params` that match up with what google will want for OAuth authentication.  

It also forces the communication with googles API to use https since this is required by google for OAuth.  I tested it using https with the old user/pass method, and that still works fine.  I think https should be what these modules use anyway.

Since google has begun sending 'suspicious sign in' emails, and also randomly preventing the password-authed logins from working (meaning that `GoogleContactsAPI` will randomly fail currently), I think using OAuth will be more and more necessary for people using WWW::Contact.  Maybe eventually (or sooner) the current one should be deprecated.

http://techie-buzz.com/online-security/gmail-suspicious-sign-in-prevented.html

This doesn't do the OAuth for you, you still need to have some external method of verifying the user via google's OAuth, and retrieving an access token to pass to `WWW::Contact::GoogleContactsAPIOAuth2`.  This can be done pretty simply with `Net::OAuth2::Client`, and I've made a working example here:

https://gist.github.com/2876064

I'd love some feedback or thoughts if you can think of a better way to accomplish this for now.  Thanks.
